### PR TITLE
Finalize BALP helpers and defaults

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1,0 +1,28 @@
+<?php
+return [
+    'app_url' => '/balp2',
+    'db_dsn' => 'mysql:host=127.0.0.1;port=3306;dbname=balp_new;charset=utf8mb4',
+    'db_user' => 'root',
+    'db_pass' => '',
+    'db' => [
+        'driver' => 'mysql',
+        'host' => '127.0.0.1',
+        'port' => 3306,
+        'database' => 'balp_new',
+        'username' => 'root',
+        'password' => '',
+        'charset' => 'utf8mb4',
+        'collation' => 'utf8mb4_czech_ci',
+    ],
+    'auth' => [
+        'enabled' => false,
+        'user_table' => 'balp_usr',
+        'username_field' => 'usr',
+        'password_field' => 'psw',
+        'role_field' => null,
+        'password_algo' => 'old_password',
+        'login_scheme' => 'usr_is_plain',
+        'jwt_secret' => 'change_me',
+        'jwt_ttl_minutes' => 120,
+    ],
+];

--- a/index.php
+++ b/index.php
@@ -1,0 +1,20 @@
+<?php
+$configPath = __DIR__ . '/config/config.php';
+if (!file_exists($configPath)) {
+    header('Location: installer.php');
+    exit;
+}
+
+require __DIR__ . '/helpers.php';
+$cfg = cfg();
+
+$target = 'public/app.html';
+if (!empty($cfg['app_url'])) {
+    $base = rtrim((string)$cfg['app_url'], '/');
+    if ($base !== '' && stripos($base, 'http') === 0) {
+        $target = $base . '/public/app.html';
+    }
+}
+
+header('Location: ' . $target);
+exit;

--- a/installer.php
+++ b/installer.php
@@ -81,7 +81,7 @@ button{padding:.6rem 1rem;border:0;border-radius:.5rem;background:#0d6efd;color:
   <fieldset><legend>Databáze</legend>
     <label>Host</label><input name="db_host" value="<?=htmlspecialchars($_POST['db_host'] ?? '127.0.0.1')?>">
     <label>Port</label><input name="db_port" value="<?=htmlspecialchars($_POST['db_port'] ?? '3306')?>">
-    <label>Název DB</label><input name="db_name" value="<?=htmlspecialchars($_POST['db_name'] ?? 'bapl_new')?>">
+    <label>Název DB</label><input name="db_name" value="<?=htmlspecialchars($_POST['db_name'] ?? 'balp_new')?>">
     <label>Uživatel</label><input name="db_user" value="<?=htmlspecialchars($_POST['db_user'] ?? '')?>">
     <label>Heslo</label><input name="db_pass" type="password" value="<?=htmlspecialchars($_POST['db_pass'] ?? '')?>">
   </fieldset>


### PR DESCRIPTION
## Summary
- add shared OLD_PASSWORD helper functions and reuse them across the API and diagnostic tools
- improve the admin user UI to detect binary OLD_PASSWORD storage, bind values correctly, and display the detected mode
- ship a default config sample, add a redirecting index.php, and fix the installer database name default

## Testing
- php -l helpers.php
- php -l api.php
- php -l db_probe.php
- php -l admin_users.php
- php -l installer.php
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68ef744450408326849d49c732ee52c5