### PR TITLE
Rozšíření správy surovin o filtry a export

### DIFF
--- a/api/sur_export_csv.php
+++ b/api/sur_export_csv.php
@@ -1,0 +1,71 @@
+<?php
+require_once __DIR__ . '/auth_helpers.php';
+require_once __DIR__ . '/jwt_helper.php';
+require_once __DIR__ . '/sur_filters.php';
+
+header('Content-Type: text/csv; charset=utf-8');
+$filename = 'balp_sur_' . date('Ymd_His') . '.csv';
+header('Content-Disposition: attachment; filename="' . $filename . '"');
+
+$config_file = dirname(__DIR__) . '/config/config.php';
+$CONFIG = [];
+if (file_exists($config_file)) require $config_file;
+$A = $CONFIG['auth'] ?? [];
+$JWT_SECRET = $A['jwt_secret'] ?? ($CONFIG['jwt_secret'] ?? (getenv('BALP_JWT_SECRET') ?: 'change_this_secret'));
+$token = balp_get_bearer_token();
+if (!$token) { http_response_code(401); echo "error: missing token"; exit; }
+try { jwt_decode($token, $JWT_SECRET, true); } catch (Exception $e) { http_response_code(401); echo 'error: ' . $e->getMessage(); exit; }
+
+try {
+  $db_dsn  = $CONFIG['db_dsn']  ?? getenv('BALP_DB_DSN');
+  $db_user = $CONFIG['db_user'] ?? getenv('BALP_DB_USER');
+  $db_pass = $CONFIG['db_pass'] ?? getenv('BALP_DB_PASS');
+  if (!$db_dsn) throw new Exception('DB DSN missing');
+  $pdo = new PDO($db_dsn, $db_user, $db_pass, [ PDO::ATTR_ERRMODE=>PDO::ERRMODE_EXCEPTION, PDO::ATTR_DEFAULT_FETCH_MODE=>PDO::FETCH_ASSOC, PDO::MYSQL_ATTR_INIT_COMMAND => "SET NAMES utf8mb4" ]);
+} catch (Exception $e) { http_response_code(500); echo 'error: ' . $e->getMessage(); exit; }
+
+$params = [];
+$where = sur_build_where($_GET, $params);
+$sort_col = sur_normalize_sort_column($_GET['sort_col'] ?? 'nazev');
+$sort_dir = strtoupper($_GET['sort_dir'] ?? 'ASC');
+$sort_dir = ($sort_dir === 'DESC') ? 'DESC' : 'ASC';
+$limit_sql = '';
+if (empty($_GET['all'])) {
+  $limit = max(1, min(1000, (int)($_GET['limit'] ?? 500)));
+  $offset = max(0, (int)($_GET['offset'] ?? 0));
+  $limit_sql = ' LIMIT :limit OFFSET :offset';
+}
+
+$sql = "SELECT id, cislo, nazev, sh, sus_sh, sus_hmot, sus_obj, okp, olej, pozn, dtod, dtdo FROM balp_sur WHERE $where ORDER BY $sort_col $sort_dir$limit_sql";
+$stmt = $pdo->prepare($sql);
+sur_bind_params($stmt, $params);
+if ($limit_sql) {
+  $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
+  $stmt->bindValue(':offset', $offset, PDO::PARAM_INT);
+}
+$stmt->execute();
+$rows = $stmt->fetchAll();
+
+$out = fopen('php://output', 'w');
+fputcsv($out, ['ID', 'Číslo', 'Název', 'SH', 'Sušina (sh)', 'Sušina (hmot)', 'Sušina (obj)', 'OKP', 'Olej', 'Poznámka', 'Platnost od', 'Platnost do'], ';');
+foreach ($rows as $row) {
+  $dtod = $row['dtod'] ? substr((string)$row['dtod'], 0, 10) : '';
+  $dtdo = $row['dtdo'] ? substr((string)$row['dtdo'], 0, 10) : '';
+  fputcsv($out, [
+    $row['id'],
+    $row['cislo'],
+    $row['nazev'],
+    $row['sh'],
+    $row['sus_sh'],
+    $row['sus_hmot'],
+    $row['sus_obj'],
+    $row['okp'],
+    $row['olej'],
+    $row['pozn'],
+    $dtod,
+    $dtdo,
+  ], ';');
+}
+
+fclose($out);
+exit;

--- a/api/sur_filters.php
+++ b/api/sur_filters.php
@@ -1,0 +1,56 @@
+<?php
+// Společné pomocné funkce pro filtry nad tabulkou balp_sur
+
+declare(strict_types=1);
+
+/**
+ * Normalize column name for ORDER BY – fallback to 'nazev'.
+ */
+function sur_normalize_sort_column(?string $column): string {
+    $allowed = ['id', 'cislo', 'nazev', 'sh', 'okp', 'olej', 'dtod', 'dtdo'];
+    $column = $column ? strtolower($column) : '';
+    foreach ($allowed as $allow) {
+        if ($column === strtolower($allow)) {
+            return $allow;
+        }
+    }
+    return 'nazev';
+}
+
+/**
+ * Build WHERE clause for common filters (search, olej flag, validity date).
+ * Returns SQL string and fills $params (by reference) with bound values.
+ */
+function sur_build_where(array $input, array &$params): string {
+    $where = ['1'];
+
+    $search = trim((string)($input['search'] ?? ''));
+    if ($search !== '') {
+        $where[] = '(nazev LIKE :search OR cislo LIKE :search)';
+        $params[':search'] = '%' . $search . '%';
+    }
+
+    $olej = trim((string)($input['olej'] ?? ''));
+    if ($olej === '1') {
+        $where[] = '(olej IS NOT NULL AND olej <> 0)';
+    } elseif ($olej === '0') {
+        $where[] = '(olej IS NULL OR olej = 0)';
+    }
+
+    $platnost = trim((string)($input['platnost'] ?? ''));
+    if ($platnost !== '' && preg_match('/^\d{4}-\d{2}-\d{2}$/', $platnost)) {
+        $params[':platnost'] = $platnost;
+        $where[] = '((dtod IS NULL OR dtod <= :platnost) AND (dtdo IS NULL OR dtdo >= :platnost))';
+    }
+
+    return implode(' AND ', $where);
+}
+
+/**
+ * Bind prepared parameters (search, platnost...).
+ */
+function sur_bind_params($stmt, array $params): void {
+    foreach ($params as $key => $value) {
+        $stmt->bindValue($key, $value, PDO::PARAM_STR);
+    }
+}

--- a/public/app.html
+++ b/public/app.html
@@ -78,6 +78,18 @@
               <input type="text" class="form-control" id="sur-search" placeholder="Zadejte část názvu nebo čísla…">
             </div>
             <div>
+              <label class="form-label mb-1 d-block">Filtrovat olej</label>
+              <select id="sur-filter-olej" class="form-select">
+                <option value="">Vše</option>
+                <option value="1">Jen olejové</option>
+                <option value="0">Bez oleje</option>
+              </select>
+            </div>
+            <div>
+              <label class="form-label mb-1 d-block" for="sur-filter-platnost">Platnost k datu</label>
+              <input type="date" class="form-control" id="sur-filter-platnost" placeholder="YYYY-MM-DD">
+            </div>
+            <div>
               <label class="form-label mb-1 d-block">Záznamů na stránku</label>
               <select id="sur-limit" class="form-select">
                 <option>10</option>
@@ -86,8 +98,10 @@
                 <option>100</option>
               </select>
             </div>
-            <div class="ms-auto">
-              <button id="sur-new" class="btn btn-success">Nová surovina</button>
+            <div class="ms-auto d-flex gap-2">
+              <button type="button" id="sur-reset" class="btn btn-outline-secondary">Reset filtrů</button>
+              <button type="button" id="sur-export" class="btn btn-outline-secondary">Export CSV</button>
+              <button type="button" id="sur-new" class="btn btn-success">Nová surovina</button>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- přidal jsem společné PHP helpery pro filtrování surovin a rozšířil seznam o filtr olejovosti i platnosti včetně statistik využití
- doplnil jsem CSV export pro suroviny a nové ovládací prvky (reset filtrů, export, datum) do webového rozhraní
- v detailu suroviny se nyní zobrazují počty využití v polotovarech pro snadnější audit

## Testing
- php -l api/sur_filters.php
- php -l api/sur_list.php
- php -l api/sur_get.php
- php -l api/sur_export_csv.php

------
https://chatgpt.com/codex/tasks/task_e_68f9e63b0d708326987785c73068f4f1