### PR TITLE
Add NH detail management APIs and UI

### DIFF
--- a/api/nh_delete.php
+++ b/api/nh_delete.php
@@ -1,0 +1,64 @@
+<?php
+require_once __DIR__ . '/auth_helpers.php';
+require_once __DIR__ . '/jwt_helper.php';
+require_once __DIR__ . '/../helpers.php';
+
+header('Content-Type: application/json; charset=utf-8');
+
+try {
+    $config = cfg();
+    $authConf = $config['auth'] ?? [];
+    if (!($authConf['enabled'] ?? false)) {
+        http_response_code(403);
+        echo json_encode(['error' => 'Auth disabled'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
+        exit;
+    }
+    $token = balp_get_bearer_token();
+    if (!$token) {
+        http_response_code(401);
+        echo json_encode(['error' => 'missing token'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
+        exit;
+    }
+    jwt_decode($token, $authConf['jwt_secret'] ?? 'change', true);
+
+    $pdo = db();
+    $id = (int)($_GET['id'] ?? 0);
+    if ($id <= 0) {
+        http_response_code(400);
+        echo json_encode(['error' => 'missing id'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
+        exit;
+    }
+
+    $check = $pdo->prepare('SELECT id FROM balp_nh WHERE id = :id AND dtod <= NOW() AND dtdo >= NOW()');
+    $check->execute([':id' => $id]);
+    if (!$check->fetchColumn()) {
+        http_response_code(404);
+        echo json_encode(['error' => 'not found'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
+        exit;
+    }
+
+    $pdo->beginTransaction();
+    $params = [':id' => $id];
+    $queries = [
+        'UPDATE balp_nh SET dtdo = DATE_SUB(NOW(), INTERVAL 1 SECOND) WHERE id = :id AND dtod <= NOW() AND dtdo >= NOW()',
+        'UPDATE balp_nhods SET dtdo = DATE_SUB(NOW(), INTERVAL 1 SECOND) WHERE idnh = :id AND dtod <= NOW() AND dtdo >= NOW()',
+        'UPDATE balp_nhods_ceny SET dtdo = DATE_SUB(NOW(), INTERVAL 1 SECOND) WHERE idnhods IN (SELECT id FROM balp_nhods WHERE idnh = :id) AND dtod <= NOW() AND dtdo >= NOW()',
+        'UPDATE balp_nhods_rec SET dtdo = DATE_SUB(NOW(), INTERVAL 1 SECOND) WHERE idnhods IN (SELECT id FROM balp_nhods WHERE idnh = :id) AND dtod <= NOW() AND dtdo >= NOW()',
+        'UPDATE balp_nhods_vyr SET dtdo = DATE_SUB(NOW(), INTERVAL 1 SECOND) WHERE idnhods IN (SELECT id FROM balp_nhods WHERE idnh = :id) AND dtod <= NOW() AND dtdo >= NOW()',
+        'UPDATE balp_nhods_vyr_rec SET dtdo = DATE_SUB(NOW(), INTERVAL 1 SECOND) WHERE idnhods IN (SELECT id FROM balp_nhods WHERE idnh = :id) AND dtod <= NOW() AND dtdo >= NOW()',
+        'UPDATE balp_nhods_vyr_zk SET dtdo = DATE_SUB(NOW(), INTERVAL 1 SECOND) WHERE idnhods IN (SELECT id FROM balp_nhods WHERE idnh = :id) AND dtod <= NOW() AND dtdo >= NOW()',
+    ];
+    foreach ($queries as $sql) {
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute($params);
+    }
+    $pdo->commit();
+
+    echo json_encode(['ok' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
+} catch (Throwable $e) {
+    if (isset($pdo) && $pdo instanceof PDO && $pdo->inTransaction()) {
+        $pdo->rollBack();
+    }
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
+}

--- a/api/nh_get.php
+++ b/api/nh_get.php
@@ -1,0 +1,43 @@
+<?php
+require_once __DIR__ . '/auth_helpers.php';
+require_once __DIR__ . '/jwt_helper.php';
+require_once __DIR__ . '/../helpers.php';
+
+header('Content-Type: application/json; charset=utf-8');
+
+try {
+    $config = cfg();
+    $authConf = $config['auth'] ?? [];
+    if (!($authConf['enabled'] ?? false)) {
+        http_response_code(403);
+        echo json_encode(['error' => 'Auth disabled'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
+        exit;
+    }
+    $token = balp_get_bearer_token();
+    if (!$token) {
+        http_response_code(401);
+        echo json_encode(['error' => 'missing token'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
+        exit;
+    }
+    jwt_decode($token, $authConf['jwt_secret'] ?? 'change', true);
+
+    $pdo = db();
+    $id = (int)($_GET['id'] ?? 0);
+    if ($id <= 0) {
+        http_response_code(400);
+        echo json_encode(['error' => 'missing id'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
+        exit;
+    }
+    $stmt = $pdo->prepare('SELECT id, kod, nazev, kategorie_id, pozn, dtod, dtdo FROM balp_nh WHERE id = :id AND dtod <= NOW() AND dtdo >= NOW()');
+    $stmt->execute([':id' => $id]);
+    $row = $stmt->fetch(PDO::FETCH_ASSOC);
+    if (!$row) {
+        http_response_code(404);
+        echo json_encode(['error' => 'not found'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
+        exit;
+    }
+    echo json_encode(['item' => $row], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
+}

--- a/api/nh_upsert.php
+++ b/api/nh_upsert.php
@@ -1,0 +1,145 @@
+<?php
+require_once __DIR__ . '/auth_helpers.php';
+require_once __DIR__ . '/jwt_helper.php';
+require_once __DIR__ . '/../helpers.php';
+
+header('Content-Type: application/json; charset=utf-8');
+
+try {
+    $config = cfg();
+    $authConf = $config['auth'] ?? [];
+    if (!($authConf['enabled'] ?? false)) {
+        http_response_code(403);
+        echo json_encode(['error' => 'Auth disabled'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
+        exit;
+    }
+    $token = balp_get_bearer_token();
+    if (!$token) {
+        http_response_code(401);
+        echo json_encode(['error' => 'missing token'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
+        exit;
+    }
+    jwt_decode($token, $authConf['jwt_secret'] ?? 'change', true);
+
+    $pdo = db();
+    $raw = file_get_contents('php://input');
+    $in = json_decode($raw, true);
+    if (!is_array($in)) {
+        $in = $_POST;
+    }
+    if (!is_array($in)) {
+        $in = [];
+    }
+    $id = isset($in['id']) ? (int)$in['id'] : 0;
+    $table = 'balp_nh';
+
+    $colsStmt = $pdo->prepare('SELECT COLUMN_NAME, DATA_TYPE, IS_NULLABLE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = :t');
+    $colsStmt->execute([':t' => $table]);
+    $columns = [];
+    while ($r = $colsStmt->fetch(PDO::FETCH_ASSOC)) {
+        $columns[$r['COLUMN_NAME']] = [
+            'type' => strtolower((string)$r['DATA_TYPE']),
+            'nullable' => ($r['IS_NULLABLE'] === 'YES')
+        ];
+    }
+
+    $sanitize = function ($val, $info) {
+        $type = $info['type'] ?? 'varchar';
+        $nullable = $info['nullable'] ?? true;
+        if ($val === null || $val === '') {
+            if ($nullable) return null;
+            switch ($type) {
+                case 'int':
+                case 'bigint':
+                case 'smallint':
+                case 'tinyint':
+                case 'mediumint':
+                case 'decimal':
+                case 'double':
+                case 'float':
+                case 'real':
+                case 'numeric':
+                    return 0;
+                default:
+                    return '';
+            }
+        }
+        switch ($type) {
+            case 'int':
+            case 'bigint':
+            case 'smallint':
+            case 'tinyint':
+            case 'mediumint':
+                return (int)$val;
+            case 'decimal':
+            case 'double':
+            case 'float':
+            case 'real':
+            case 'numeric':
+                return is_numeric($val) ? (float)$val : 0;
+            default:
+                return (string)$val;
+        }
+    };
+
+    $pdo->beginTransaction();
+    if ($id > 0) {
+        $setParts = [];
+        $params = [':id' => $id];
+        foreach ($in as $key => $value) {
+            if ($key === 'id' || !isset($columns[$key])) continue;
+            $sanitized = $sanitize($value, $columns[$key]);
+            $placeholder = ':' . $key;
+            $setParts[] = '`' . str_replace('`', '``', $key) . "` = $placeholder";
+            $params[$placeholder] = $sanitized;
+        }
+        if ($setParts) {
+            $sql = 'UPDATE `' . $table . '` SET ' . implode(',', $setParts) . ' WHERE id = :id';
+            $stmt = $pdo->prepare($sql);
+            foreach ($params as $p => $v) {
+                if ($p === ':id') {
+                    $stmt->bindValue($p, (int)$v, PDO::PARAM_INT);
+                } elseif ($v === null) {
+                    $stmt->bindValue($p, null, PDO::PARAM_NULL);
+                } else {
+                    $stmt->bindValue($p, $v);
+                }
+            }
+            $stmt->execute();
+        }
+    } else {
+        $cols = [];
+        $placeholders = [];
+        $params = [];
+        foreach ($in as $key => $value) {
+            if ($key === 'id' || !isset($columns[$key])) continue;
+            $sanitized = $sanitize($value, $columns[$key]);
+            $cols[] = '`' . str_replace('`', '``', $key) . '`';
+            $placeholder = ':' . $key;
+            $placeholders[] = $placeholder;
+            $params[$placeholder] = $sanitized;
+        }
+        if ($cols) {
+            $sql = 'INSERT INTO `' . $table . '` (' . implode(',', $cols) . ') VALUES (' . implode(',', $placeholders) . ')';
+            $stmt = $pdo->prepare($sql);
+            foreach ($params as $p => $v) {
+                if ($v === null) {
+                    $stmt->bindValue($p, null, PDO::PARAM_NULL);
+                } else {
+                    $stmt->bindValue($p, $v);
+                }
+            }
+            $stmt->execute();
+        } else {
+            throw new Exception('No data to insert');
+        }
+    }
+    $pdo->commit();
+    echo json_encode(new stdClass());
+} catch (Throwable $e) {
+    if (isset($pdo) && $pdo instanceof PDO && $pdo->inTransaction()) {
+        $pdo->rollBack();
+    }
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
+}

--- a/helpers.php
+++ b/helpers.php
@@ -58,7 +58,7 @@ function db() {
         respond_json(['error' => 'DB connect failed', 'detail' => $err], 500);
     }
     // Ensure utf8mb4
-    try { $pdo->exec("SET NAMES utf8mb4 COLLATE utf8mb4_czech_ci"); } catch (Throwable $e) {}
+    try { $pdo->exec("SET NAMES utf8mb4"); } catch (Throwable $e) {}
     return $pdo;
 }
 

--- a/public/js/nh.controller.js
+++ b/public/js/nh.controller.js
@@ -64,7 +64,7 @@
       const code = r.kod ?? r.code ?? r.cislo ?? r.CISLO ?? r.CODE ?? '';
       const name = r.nazev ?? r.name ?? r.NAZEV ?? r.NAME ?? '';
       const cat  = r.kategorie_id ?? r.category_id ?? r.kategorie ?? r.CAT ?? '';
-      return `<tr>
+      return `<tr data-id="${id!==null?String(id):''}" style="cursor:pointer">
         <td>${id!==null?String(id):''}</td>
         <td>${code!==null?String(code):''}</td>
         <td>${name!==null?String(name):''}</td>
@@ -74,8 +74,8 @@
     el.table.innerHTML = rows || `<tr><td colspan="4"><em>Žádné výsledky.</em></td></tr>`;
   }
 
-  async function load() {
-    if (state.loading) return;
+  async function load(force=false) {
+    if (state.loading && !force) return;
     state.loading = true;
     setMeta('Načítám…');
     try {
@@ -154,4 +154,130 @@
   } catch {}
   // Když už je NH aktivní hned po načtení
   if (el.tabBtn && el.tabBtn.classList.contains('active')) onShown({target: el.tabBtn});
+
+  // Bind events pro NH detail modal
+  if (el.table) {
+    el.table.addEventListener('click', (e) => {
+      const tr = e.target.closest('tr');
+      if (!tr) return;
+      const id = tr.getAttribute('data-id');
+      if (id) openDetail(id);
+    });
+  }
+  const modalEl = document.getElementById('nhModal');
+  let modal = null;
+  if (modalEl) {
+    let ModalCtor = null;
+    if (window.bootstrap && typeof window.bootstrap.Modal === 'function') {
+      ModalCtor = window.bootstrap.Modal;
+    } else if (typeof bootstrap !== 'undefined' && bootstrap && typeof bootstrap.Modal === 'function') {
+      ModalCtor = bootstrap.Modal;
+    }
+    if (ModalCtor) {
+      modal = new ModalCtor(modalEl);
+    }
+  }
+  const f = {
+    id: document.getElementById('nh-id'),
+    kod: document.getElementById('nh-kod'),
+    nazev: document.getElementById('nh-nazev'),
+    kategorie_id: document.getElementById('nh-kategorie_id'),
+    pozn: document.getElementById('nh-poznamka'),
+    dtod: document.getElementById('nh-dtod'),
+    dtdo: document.getElementById('nh-dtdo'),
+  };
+  const detailMeta = document.getElementById('nh-detail-meta');
+  const btnEdit = document.getElementById('btn-nh-edit');
+  const btnSave = document.getElementById('btn-nh-save');
+  const btnDel = document.getElementById('btn-nh-delete');
+  const btnNew = document.getElementById('nh-new');
+  if (btnEdit) btnEdit.addEventListener('click', () => setEditMode(true));
+  if (btnSave) btnSave.addEventListener('click', () => saveDetail());
+  if (btnDel) btnDel.addEventListener('click', () => deleteCurrent());
+  if (btnNew) btnNew.addEventListener('click', () => newItem());
+
+  function setEditMode(on) {
+    Object.keys(f).filter(k => k !== 'id').forEach(k => { if (f[k]) f[k].disabled = !on; });
+    if (btnEdit) btnEdit.classList.toggle('d-none', on);
+    if (btnSave) btnSave.classList.toggle('d-none', !on);
+  }
+  function fillForm(row) {
+    const set = (k, v) => { if (f[k]) f[k].value = (v ?? ''); };
+    set('id', row.id ?? '');
+    set('kod', row.kod ?? row.code ?? row.cislo ?? '');
+    set('nazev', row.nazev ?? row.name ?? '');
+    set('kategorie_id', row.kategorie_id ?? row.kategorie ?? '');
+    set('pozn', row.pozn ?? '');
+    set('dtod', row.dtod ? String(row.dtod).substring(0, 10) : '');
+    set('dtdo', row.dtdo ? String(row.dtdo).substring(0, 10) : '');
+  }
+  function formToPayload() {
+    const read = (id) => {
+      const v = f[id]?.value ?? '';
+      if (id === 'kategorie_id') return v === '' ? null : parseInt(v, 10);
+      return v === '' ? null : v;
+    };
+    const payload = {
+      kod: read('kod'),
+      nazev: read('nazev'),
+      kategorie_id: read('kategorie_id'),
+      pozn: read('pozn'),
+      dtod: read('dtod'),
+      dtdo: read('dtdo'),
+    };
+    const idVal = f.id?.value;
+    if (idVal) payload.id = Number(idVal);
+    return payload;
+  }
+  async function openDetail(id) {
+    if (!modal) return;
+    try {
+      const data = await apiFetch(apiBase + '/api/nh_get.php?id=' + encodeURIComponent(id));
+      const row = data.item ?? data;
+      fillForm(row);
+      if (detailMeta) detailMeta.textContent = `ID #${id}`;
+      setEditMode(false);
+      modal.show();
+    } catch (e) {
+      console.error('Detail load failed:', e);
+      if (el.meta) el.meta.textContent = e.message || 'Chyba při načítání detailu';
+    }
+  }
+  function newItem() {
+    if (!modal) return;
+    fillForm({});
+    if (detailMeta) detailMeta.textContent = 'Nová NH';
+    setEditMode(true);
+    modal.show();
+  }
+  async function saveDetail() {
+    try {
+      const payload = formToPayload();
+      await apiFetch(apiBase + '/api/nh_upsert.php', { method: 'POST', body: JSON.stringify(payload) });
+      if (modal) modal.hide();
+      state.offset = 0;
+      await load(true);
+    } catch (e) {
+      console.error('Save failed:', e);
+      alert('Uložení selhalo: ' + (e.message || e));
+    }
+  }
+  async function deleteCurrent() {
+    const id = f.id?.value;
+    if (!id) {
+      alert('Záznam nemá ID.');
+      return;
+    }
+    if (!confirm('Opravdu smazat tuto položku NH?')) return;
+    try {
+      await apiFetch(apiBase + '/api/nh_delete.php?id=' + encodeURIComponent(id), { method: 'POST' });
+      if (modal) modal.hide();
+      state.offset = 0;
+      await load(true);
+      if (detailMeta) detailMeta.textContent = '';
+    } catch (e) {
+      console.error('Delete failed:', e);
+      alert('Smazání selhalo: ' + (e.message || e));
+    }
+  }
 })();


### PR DESCRIPTION
## Summary
- add nh_get, nh_upsert, and nh_delete API endpoints guarded by JWT auth
- update the NH table view to open a modal for editing, saving, and deleting records
- ensure database connections default to utf8mb4

## Testing
- php -l api/nh_get.php
- php -l api/nh_upsert.php
- php -l api/nh_delete.php

------
https://chatgpt.com/codex/tasks/task_b_690339c796688329abf8f595a8cda9a1