### PR TITLE
Fix NH endpoints and modal tab navigation

### DIFF
--- a/api/nh_delete.php
+++ b/api/nh_delete.php
@@ -9,49 +9,50 @@ try {
     $config = cfg();
     $authConf = $config['auth'] ?? [];
     if (!($authConf['enabled'] ?? false)) {
-        http_response_code(403);
-        echo json_encode(['error' => 'Auth disabled'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
-        exit;
+        respond_json(['error' => 'Auth disabled'], 403);
     }
+
     $token = balp_get_bearer_token();
     if (!$token) {
-        http_response_code(401);
-        echo json_encode(['error' => 'missing token'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
-        exit;
+        respond_json(['error' => 'missing token'], 401);
     }
+
     jwt_decode($token, $authConf['jwt_secret'] ?? 'change', true);
 
     $pdo = db();
     $id = (int)($_GET['id'] ?? 0);
     if ($id <= 0) {
-        http_response_code(400);
-        echo json_encode(['error' => 'missing id'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
-        exit;
+        respond_json(['error' => 'missing id'], 400);
     }
 
-    $check = $pdo->prepare('SELECT id FROM balp_nh WHERE id = :id AND dtod <= NOW() AND dtdo >= NOW()');
+    $check = $pdo->prepare('SELECT id FROM balp_nh WHERE id = :id');
     $check->execute([':id' => $id]);
     if (!$check->fetchColumn()) {
-        http_response_code(404);
-        echo json_encode(['error' => 'not found'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
-        exit;
+        respond_json(['error' => 'not found'], 404);
     }
 
+    $now = (new DateTimeImmutable('now'))->format('Y-m-d');
+
     $pdo->beginTransaction();
-    $params = [':id' => $id];
-    $queries = [
-        'UPDATE balp_nh SET dtdo = DATE_SUB(NOW(), INTERVAL 1 SECOND) WHERE id = :id AND dtod <= NOW() AND dtdo >= NOW()',
-        'UPDATE balp_nhods SET dtdo = DATE_SUB(NOW(), INTERVAL 1 SECOND) WHERE idnh = :id AND dtod <= NOW() AND dtdo >= NOW()',
-        'UPDATE balp_nhods_ceny SET dtdo = DATE_SUB(NOW(), INTERVAL 1 SECOND) WHERE idnhods IN (SELECT id FROM balp_nhods WHERE idnh = :id) AND dtod <= NOW() AND dtdo >= NOW()',
-        'UPDATE balp_nhods_rec SET dtdo = DATE_SUB(NOW(), INTERVAL 1 SECOND) WHERE idnhods IN (SELECT id FROM balp_nhods WHERE idnh = :id) AND dtod <= NOW() AND dtdo >= NOW()',
-        'UPDATE balp_nhods_vyr SET dtdo = DATE_SUB(NOW(), INTERVAL 1 SECOND) WHERE idnhods IN (SELECT id FROM balp_nhods WHERE idnh = :id) AND dtod <= NOW() AND dtdo >= NOW()',
-        'UPDATE balp_nhods_vyr_rec SET dtdo = DATE_SUB(NOW(), INTERVAL 1 SECOND) WHERE idnhods IN (SELECT id FROM balp_nhods WHERE idnh = :id) AND dtod <= NOW() AND dtdo >= NOW()',
-        'UPDATE balp_nhods_vyr_zk SET dtdo = DATE_SUB(NOW(), INTERVAL 1 SECOND) WHERE idnhods IN (SELECT id FROM balp_nhods WHERE idnh = :id) AND dtod <= NOW() AND dtdo >= NOW()',
+
+    $tables = [
+        'balp_nh' => 'id = :id',
+        'balp_nhods' => 'idnh = :id',
+        'balp_nhods_ceny' => 'idnhods IN (SELECT id FROM balp_nhods WHERE idnh = :id)',
+        'balp_nhods_rec' => 'idnhods IN (SELECT id FROM balp_nhods WHERE idnh = :id)',
+        'balp_nhods_vyr' => 'idnhods IN (SELECT id FROM balp_nhods WHERE idnh = :id)',
+        'balp_nhods_vyr_rec' => 'idnhods IN (SELECT id FROM balp_nhods WHERE idnh = :id)',
+        'balp_nhods_vyr_zk' => 'idnhods IN (SELECT id FROM balp_nhods WHERE idnh = :id)',
     ];
-    foreach ($queries as $sql) {
+
+    foreach ($tables as $table => $condition) {
+        $sql = "UPDATE $table SET dtdo = :now WHERE $condition AND dtod < :now AND dtdo > :now";
         $stmt = $pdo->prepare($sql);
-        $stmt->execute($params);
+        $stmt->bindValue(':now', $now);
+        $stmt->bindValue(':id', $id, PDO::PARAM_INT);
+        $stmt->execute();
     }
+
     $pdo->commit();
 
     echo json_encode(['ok' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);

--- a/api/nh_list.php
+++ b/api/nh_list.php
@@ -5,184 +5,107 @@ require_once __DIR__ . '/../helpers.php';
 
 header('Content-Type: application/json; charset=utf-8');
 
-$config = cfg();
-$authConf = $config['auth'] ?? [];
-
-if (!($authConf['enabled'] ?? false)) {
-    http_response_code(403);
-    echo json_encode(['error' => 'Auth disabled'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
-    exit;
-}
-
-$token = balp_get_bearer_token();
-if (!$token) {
-    http_response_code(401);
-    echo json_encode(['error' => 'missing token'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
-    exit;
-}
-
 try {
+    $config = cfg();
+    $authConf = $config['auth'] ?? [];
+    if (!($authConf['enabled'] ?? false)) {
+        respond_json(['error' => 'Auth disabled'], 403);
+    }
+
+    $token = balp_get_bearer_token();
+    if (!$token) {
+        respond_json(['error' => 'missing token'], 401);
+    }
+
     jwt_decode($token, $authConf['jwt_secret'] ?? 'change', true);
-} catch (Exception $e) {
-    http_response_code(401);
-    echo json_encode(['error' => $e->getMessage()], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
-    exit;
-}
 
-$pdo = db();
+    $pdo = db();
 
-$tableParam = $_GET['table'] ?? 'balp_nh';
-$allowedTables = [
-    'balp_nh',
-    'balp_nhods',
-    'balp_nhods_ceny',
-    'balp_nhods_rec',
-    'balp_nhods_vyr',
-    'balp_nhods_vyr_rec',
-    'balp_nhods_vyr_zk',
-];
+    $limit = max(1, min(200, (int)($_GET['limit'] ?? 50)));
+    $offset = max(0, (int)($_GET['offset'] ?? 0));
+    $search = trim((string)($_GET['q'] ?? ''));
 
-$table = null;
-foreach ($allowedTables as $candidate) {
-    if (strcasecmp($candidate, $tableParam) === 0) {
-        $table = $candidate;
-        break;
+    $codeFrom = $_GET['cislo_od'] ?? $_GET['od'] ?? null;
+    $codeTo   = $_GET['cislo_do'] ?? $_GET['do'] ?? null;
+    $active   = $_GET['active'] ?? $_GET['platne'] ?? '1';
+
+    $normalizeCode = static function ($value) {
+        $value = trim((string)$value);
+        if ($value === '') {
+            return null;
+        }
+        $upper = mb_strtoupper($value, 'UTF-8');
+        if (preg_match('/^-?\d+$/', $upper)) {
+            $isNegative = strpos($upper, '-') === 0;
+            $digits = ltrim($upper, '-');
+            $padded = str_pad($digits, 12, '0', STR_PAD_LEFT);
+            return $isNegative ? '-' . $padded : $padded;
+        }
+        return $upper;
+    };
+
+    $codeFrom = $normalizeCode($codeFrom);
+    $codeTo   = $normalizeCode($codeTo);
+
+    $where = [];
+    $params = [];
+
+    if ($search !== '') {
+        $params[':search'] = '%' . $search . '%';
+        $where[] = '(cislo LIKE :search OR nazev LIKE :search OR pozn LIKE :search)';
     }
-}
-if (!$table) {
-    http_response_code(400);
-    echo json_encode(['error' => 'Unsupported table'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
-    exit;
-}
 
-$schema = $config['db']['database'] ?? null;
-if (!$schema) {
+    if ($codeFrom !== null) {
+        $params[':cislo_od'] = $codeFrom;
+        $where[] = 'cislo >= :cislo_od';
+    }
+
+    if ($codeTo !== null) {
+        $params[':cislo_do'] = $codeTo;
+        $where[] = 'cislo <= :cislo_do';
+    }
+
+    if ($active !== null && $active !== '') {
+        $flag = in_array(strtolower((string)$active), ['1', 'true', 'yes', 'ano'], true);
+        if ($flag) {
+            $where[] = '(dtod <= NOW() AND dtdo > NOW())';
+        }
+    }
+
+    $whereSql = $where ? ('WHERE ' . implode(' AND ', $where)) : '';
+
+    $countStmt = $pdo->prepare("SELECT COUNT(*) FROM balp_nh $whereSql");
+    foreach ($params as $k => $v) {
+        $countStmt->bindValue($k, $v);
+    }
+    $countStmt->execute();
+    $total = (int)$countStmt->fetchColumn();
+
+    $sql = "SELECT id, cislo, nazev, pozn, dtod, dtdo, NULL AS kategorie_id FROM balp_nh $whereSql ORDER BY cislo LIMIT :limit OFFSET :offset";
+    $stmt = $pdo->prepare($sql);
+    foreach ($params as $k => $v) {
+        $stmt->bindValue($k, $v);
+    }
+    $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
+    $stmt->bindValue(':offset', $offset, PDO::PARAM_INT);
+    $stmt->execute();
+
+    $rows = $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    foreach ($rows as &$row) {
+        $row['kod'] = $row['cislo'];
+        $row['name'] = $row['nazev'];
+    }
+    unset($row);
+
+    echo json_encode([
+        'limit' => $limit,
+        'offset' => $offset,
+        'total' => $total,
+        'items' => $rows,
+    ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
+} catch (Throwable $e) {
     http_response_code(500);
-    echo json_encode(['error' => 'Database schema missing in configuration'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
-    exit;
+    echo json_encode([
+        'error' => $e->getMessage(),
+    ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
 }
-
-$columnsStmt = $pdo->prepare("SELECT COLUMN_NAME, DATA_TYPE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = :schema AND TABLE_NAME = :table");
-$columnsStmt->execute([':schema' => $schema, ':table' => $table]);
-$columns = $columnsStmt->fetchAll(PDO::FETCH_ASSOC);
-if (!$columns) {
-    http_response_code(404);
-    echo json_encode(['error' => 'Table not found'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
-    exit;
-}
-
-$columnNames = array_column($columns, 'COLUMN_NAME');
-
-$detect = function(array $candidates) use ($columnNames) {
-    foreach ($candidates as $cand) {
-        foreach ($columnNames as $col) {
-            if (strcasecmp($col, $cand) === 0) {
-                return $col;
-            }
-        }
-    }
-    foreach ($columnNames as $col) {
-        foreach ($candidates as $cand) {
-            if (stripos($col, $cand) !== false) {
-                return $col;
-            }
-        }
-    }
-    return null;
-};
-
-$idColumn = $detect(['id', 'id_nh', 'nh_id', 'idnh', 'idpol']);
-$codeColumn = $detect(['kod', 'code', 'cislo', 'oznaceni', 'cis']);
-$nameColumn = $detect(['nazev', 'name', 'popis', 'description', 'oznaceni']);
-$categoryColumn = $detect(['kategorie_id', 'kategorie', 'category', 'kat']);
-
-$textColumns = [];
-foreach ($columns as $col) {
-    $type = strtolower($col['DATA_TYPE'] ?? '');
-    if (in_array($type, ['char', 'varchar', 'text', 'tinytext', 'mediumtext', 'longtext'])) {
-        $textColumns[] = $col['COLUMN_NAME'];
-    }
-}
-
-$limit = max(1, min(200, (int)($_GET['limit'] ?? 50)));
-$offset = max(0, (int)($_GET['offset'] ?? 0));
-$q = trim((string)($_GET['q'] ?? ''));
-$categoryFilter = $_GET['category'] ?? $_GET['kategorie'] ?? null;
-
-$whereParts = [];
-$params = [];
-if ($q !== '' && $textColumns) {
-    $searchColumns = [];
-    if ($codeColumn && in_array($codeColumn, $textColumns, true)) $searchColumns[] = $codeColumn;
-    if ($nameColumn && in_array($nameColumn, $textColumns, true)) $searchColumns[] = $nameColumn;
-    if (!$searchColumns) $searchColumns = $textColumns;
-    $likeParts = [];
-    foreach ($searchColumns as $idx => $col) {
-        $param = ':q' . $idx;
-        $likeParts[] = '`' . str_replace('`', '``', $col) . "` LIKE $param";
-        $params[$param] = '%' . $q . '%';
-    }
-    if ($likeParts) {
-        $whereParts[] = '(' . implode(' OR ', $likeParts) . ')';
-    }
-}
-
-if ($categoryFilter !== null && $categoryColumn) {
-    $whereParts[] = '`' . str_replace('`', '``', $categoryColumn) . '` = :category';
-    $params[':category'] = $categoryFilter;
-}
-
-$whereSql = $whereParts ? ('WHERE ' . implode(' AND ', $whereParts)) : '';
-$orderColumn = $nameColumn ?? $codeColumn ?? $idColumn ?? $columnNames[0];
-$orderSql = '`' . str_replace('`', '``', $orderColumn) . '`';
-
-$countSql = 'SELECT COUNT(*) FROM `' . str_replace('`', '``', $table) . '` ' . $whereSql;
-$countStmt = $pdo->prepare($countSql);
-foreach ($params as $key => $value) {
-    $countStmt->bindValue($key, $value);
-}
-$countStmt->execute();
-$total = (int)$countStmt->fetchColumn();
-
-$sql = 'SELECT * FROM `' . str_replace('`', '``', $table) . '` ' . $whereSql . ' ORDER BY ' . $orderSql . ' LIMIT :limit OFFSET :offset';
-$stmt = $pdo->prepare($sql);
-foreach ($params as $key => $value) {
-    $stmt->bindValue($key, $value);
-}
-$stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
-$stmt->bindValue(':offset', $offset, PDO::PARAM_INT);
-$stmt->execute();
-$rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
-
-foreach ($rows as &$row) {
-    if ($idColumn && !array_key_exists('id', $row) && array_key_exists($idColumn, $row)) {
-        $row['id'] = $row[$idColumn];
-    }
-    if ($codeColumn && !array_key_exists('kod', $row) && array_key_exists($codeColumn, $row)) {
-        $row['kod'] = $row[$codeColumn];
-    }
-    if ($codeColumn && !array_key_exists('code', $row) && array_key_exists($codeColumn, $row)) {
-        $row['code'] = $row[$codeColumn];
-    }
-    if ($nameColumn && !array_key_exists('nazev', $row) && array_key_exists($nameColumn, $row)) {
-        $row['nazev'] = $row[$nameColumn];
-    }
-    if ($nameColumn && !array_key_exists('name', $row) && array_key_exists($nameColumn, $row)) {
-        $row['name'] = $row[$nameColumn];
-    }
-    if ($categoryColumn && !array_key_exists('kategorie_id', $row) && array_key_exists($categoryColumn, $row)) {
-        $row['kategorie_id'] = $row[$categoryColumn];
-    }
-    if ($categoryColumn && !array_key_exists('kategorie', $row) && array_key_exists($categoryColumn, $row)) {
-        $row['kategorie'] = $row[$categoryColumn];
-    }
-}
-unset($row);
-
-echo json_encode([
-    'table' => $table,
-    'limit' => $limit,
-    'offset' => $offset,
-    'total' => $total,
-    'items' => $rows,
-], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);

--- a/public/app.html
+++ b/public/app.html
@@ -368,7 +368,9 @@
         <li class="nav-item" role="presentation">
           <button class="nav-link" id="vp-pol-tab" data-bs-toggle="tab" data-bs-target="#vp-tab-pol" type="button" role="tab">Polotovary</button>
         </li>
-        <li class="nav-item"><a class="nav-link" href="../admin_users.php">Uživatelé</a></li>
+        <li class="nav-item" role="presentation">
+          <button class="nav-link" type="button" id="vp-users-link">Uživatelé</button>
+        </li>
 </ul>
       <div class="tab-content mt-2">
         <div class="tab-pane fade show active" id="vp-tab-sur" role="tabpanel" aria-labelledby="vp-sur-tab">

--- a/public/js/pol.vyrobni-prikaz.js
+++ b/public/js/pol.vyrobni-prikaz.js
@@ -15,6 +15,15 @@
     hdr.appendChild(btn);
   });
 
+  document.addEventListener('DOMContentLoaded', () => {
+    const usersBtn = document.getElementById('vp-users-link');
+    if (usersBtn) {
+      usersBtn.addEventListener('click', () => {
+        window.open('../admin_users.php', '_blank', 'noopener');
+      });
+    }
+  });
+
   async function onRecurseClick() {
     try {
       const kg    = Number(document.getElementById('vp-mnozstvi').value || 1);


### PR DESCRIPTION
## Summary
- replace the generic NH list endpoint with a dedicated implementation that normalises codes, filters by range, and returns active rows using `[dtod, dtdo)` intervals
- harden NH detail, upsert, and delete APIs to use consistent columns, validate input, enforce unique codes, and close validity ranges transactionally
- update the VP modal to use a button for the "Uživatelé" link and open it in a new tab to avoid Bootstrap selector errors

## Testing
- php -l api/nh_list.php
- php -l api/nh_get.php
- php -l api/nh_upsert.php
- php -l api/nh_delete.php

------
https://chatgpt.com/codex/tasks/task_b_690346f2264083299bd573c4d00a71d2