### PR TITLE
Prevent helper header redeclaration

### DIFF
--- a/helpers.php
+++ b/helpers.php
@@ -62,16 +62,18 @@ function db() {
     return $pdo;
 }
 
-function balp_getallheaders() {
-    if (function_exists('getallheaders')) return getallheaders();
-    $headers = [];
-    foreach ($_SERVER as $name => $value) {
-        if (strpos($name, 'HTTP_') === 0) {
-            $key = str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($name, 5)))));
-            $headers[$key] = $value;
+if (!function_exists('balp_getallheaders')) {
+    function balp_getallheaders() {
+        if (function_exists('getallheaders')) return getallheaders();
+        $headers = [];
+        foreach ($_SERVER as $name => $value) {
+            if (strpos($name, 'HTTP_') === 0) {
+                $key = str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($name, 5)))));
+                $headers[$key] = $value;
+            }
         }
+        return $headers;
     }
-    return $headers;
 }
 
 function get_bearer_token() {


### PR DESCRIPTION
## Summary
- wrap the helper balp_getallheaders definition in a function_exists guard to avoid redeclaration fatals when API endpoints include both helper files

## Testing
- php api/nh_list.php


------
https://chatgpt.com/codex/tasks/task_b_690348da84e08329b5ea22cdc7452c17