### PR TITLE
Add detailed NH data retrieval and UI

### DIFF
--- a/api/nh_get.php
+++ b/api/nh_get.php
@@ -39,7 +39,133 @@ try {
     $row['name'] = $row['nazev'];
     $row['kategorie_id'] = $row['kategorie_id'] ?? null;
 
-    echo json_encode(['item' => $row], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
+    $normalizeDate = static function ($value) {
+        if ($value === null || $value === '') {
+            return null;
+        }
+        $value = (string)$value;
+        if (strlen($value) >= 10) {
+            return substr($value, 0, 10);
+        }
+        return $value;
+    };
+    $row['dtod'] = $normalizeDate($row['dtod'] ?? null);
+    $row['dtdo'] = $normalizeDate($row['dtdo'] ?? null);
+
+    $tableExists = static function (PDO $pdo, string $table) {
+        try {
+            $pdo->query('SELECT 1 FROM ' . sql_quote_ident($table) . ' LIMIT 0');
+            return true;
+        } catch (Throwable $e) {
+            return false;
+        }
+    };
+
+    $detail = [
+        'item' => $row,
+        'ods' => [],
+    ];
+
+    $hasNhOds = $tableExists($pdo, 'balp_nhods');
+    $hasNhOdsCeny = $tableExists($pdo, 'balp_nhods_ceny');
+    $hasNhOdsRec = $tableExists($pdo, 'balp_nhods_rec');
+    $hasSur = $tableExists($pdo, 'balp_sur');
+    $hasPol = $tableExists($pdo, 'balp_pol');
+
+    if ($hasNhOds) {
+        $nhodsTable = sql_quote_ident('balp_nhods');
+        $odsStmt = $pdo->prepare("SELECT id, idnh, cislo, nazev, pozn, dtod, dtdo FROM $nhodsTable WHERE idnh = :id ORDER BY cislo, id");
+        $odsStmt->execute([':id' => $id]);
+        $odsRows = $odsStmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+
+        foreach ($odsRows as $odsRow) {
+            $odsId = (int)($odsRow['id'] ?? 0);
+            $odsRow['dtod'] = $normalizeDate($odsRow['dtod'] ?? null);
+            $odsRow['dtdo'] = $normalizeDate($odsRow['dtdo'] ?? null);
+
+            $odsRow['active_price'] = null;
+            $odsRow['prices'] = [];
+            $odsRow['recipe'] = [];
+
+            if ($hasNhOdsCeny && $odsId > 0) {
+                $cenyTable = sql_quote_ident('balp_nhods_ceny');
+                $activePriceStmt = $pdo->prepare(
+                    "SELECT id, idnhods, sur_nak, mat_nak, vn_kg, uvn_kg, dtod, dtdo
+                     FROM $cenyTable
+                     WHERE idnhods = :ods_id
+                       AND (dtod IS NULL OR dtod <= NOW())
+                       AND (dtdo IS NULL OR dtdo > NOW())
+                     ORDER BY dtod DESC
+                     LIMIT 1"
+                );
+                $activePriceStmt->execute([':ods_id' => $odsId]);
+                $activePrice = $activePriceStmt->fetch(PDO::FETCH_ASSOC) ?: null;
+                if ($activePrice) {
+                    $activePrice['dtod'] = $normalizeDate($activePrice['dtod'] ?? null);
+                    $activePrice['dtdo'] = $normalizeDate($activePrice['dtdo'] ?? null);
+                }
+                $odsRow['active_price'] = $activePrice;
+
+                $pricesStmt = $pdo->prepare(
+                    "SELECT id, idnhods, sur_nak, mat_nak, vn_kg, uvn_kg, dtod, dtdo
+                     FROM $cenyTable
+                     WHERE idnhods = :ods_id
+                     ORDER BY dtod DESC, id DESC"
+                );
+                $pricesStmt->execute([':ods_id' => $odsId]);
+                $prices = $pricesStmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+                foreach ($prices as &$priceRow) {
+                    $priceRow['dtod'] = $normalizeDate($priceRow['dtod'] ?? null);
+                    $priceRow['dtdo'] = $normalizeDate($priceRow['dtdo'] ?? null);
+                }
+                unset($priceRow);
+                $odsRow['prices'] = $prices;
+            }
+
+            if ($hasNhOdsRec && $odsId > 0) {
+                $recTable = sql_quote_ident('balp_nhods_rec');
+                $surTable = $hasSur ? sql_quote_ident('balp_sur') : null;
+                $polTable = $hasPol ? sql_quote_ident('balp_pol') : null;
+
+                $joins = [];
+                if ($surTable) {
+                    $joins[] = "LEFT JOIN $surTable AS sur ON rec.idsur = sur.id";
+                }
+                if ($polTable) {
+                    $joins[] = "LEFT JOIN $polTable AS pol ON rec.idpol = pol.id";
+                }
+                $joinsSql = $joins ? (" " . implode(" ", $joins)) : '';
+
+                $recipeSql = "SELECT rec.id, rec.idsur, rec.idpol, rec.techpor, rec.gkg, rec.dtod, rec.dtdo,
+                        " . ($surTable ? 'sur.cislo AS sur_cislo, sur.nazev AS sur_nazev,' : 'NULL AS sur_cislo, NULL AS sur_nazev,') .
+                        ($polTable ? ' pol.cislo AS pol_cislo, pol.nazev AS pol_nazev' : ' NULL AS pol_cislo, NULL AS pol_nazev') .
+                    " FROM $recTable AS rec$joinsSql
+                       WHERE rec.idnhods = :ods_id
+                         AND (rec.dtod IS NULL OR rec.dtod <= NOW())
+                         AND (rec.dtdo IS NULL OR rec.dtdo >= NOW())
+                     ORDER BY rec.techpor, COALESCE(sur_cislo, pol_cislo, ''), rec.id";
+
+                $recipeStmt = $pdo->prepare($recipeSql);
+                $recipeStmt->execute([':ods_id' => $odsId]);
+                $recipeRows = $recipeStmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+                foreach ($recipeRows as &$recRow) {
+                    $recRow['dtod'] = $normalizeDate($recRow['dtod'] ?? null);
+                    $recRow['dtdo'] = $normalizeDate($recRow['dtdo'] ?? null);
+                    $cislo = $recRow['sur_cislo'] ?? $recRow['pol_cislo'] ?? null;
+                    $nazev = $recRow['sur_nazev'] ?? $recRow['pol_nazev'] ?? null;
+                    $recRow['cislo'] = $cislo;
+                    $recRow['nazev'] = $nazev;
+                    $recRow['typ'] = ($recRow['idsur'] ?? 0) ? 'sur' : (($recRow['idpol'] ?? 0) ? 'pol' : null);
+                }
+                unset($recRow);
+                $odsRow['recipe'] = $recipeRows;
+            }
+
+            $detail['ods'][] = $odsRow;
+        }
+    }
+
+    echo json_encode($detail, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);
 } catch (Throwable $e) {
     http_response_code(500);
     echo json_encode(['error' => $e->getMessage()], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE);

--- a/public/app.html
+++ b/public/app.html
@@ -106,7 +106,8 @@
                 <option>100</option>
               </select>
             </div>
-            <div class="ms-auto d-flex gap-2">
+            <div class="ms-auto d-flex flex-wrap gap-2 justify-content-end">
+              <button type="button" id="nh-new" class="btn btn-success">Nová NH</button>
               <button type="button" id="nh-reset" class="btn btn-outline-secondary">Reset filtrů</button>
               <div class="btn-group" role="group" aria-label="Stránkování">
                 <button class="btn btn-outline-secondary" id="nh-prev">&laquo; Předchozí</button>
@@ -264,6 +265,64 @@
 
   <div class="text-end mt-3">
     <a href="./diag.html" class="link-secondary small">Diagnostika přihlášení</a>
+  </div>
+
+  <!-- Detail NH modal -->
+  <div class="modal fade" id="nhModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-xl modal-dialog-scrollable">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Detail Nátěrové hmoty</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Zavřít"></button>
+        </div>
+        <div class="modal-body">
+          <div class="row g-3">
+            <div class="col-sm-2">
+              <label for="nh-id" class="form-label">ID</label>
+              <input type="text" class="form-control" id="nh-id" disabled>
+            </div>
+            <div class="col-sm-3">
+              <label for="nh-kod" class="form-label">Kód</label>
+              <input type="text" class="form-control" id="nh-kod" disabled>
+            </div>
+            <div class="col-sm-7">
+              <label for="nh-nazev" class="form-label">Název</label>
+              <input type="text" class="form-control" id="nh-nazev" disabled>
+            </div>
+            <div class="col-sm-3">
+              <label for="nh-kategorie_id" class="form-label">Kategorie</label>
+              <input type="number" class="form-control" id="nh-kategorie_id" disabled>
+            </div>
+            <div class="col-sm-3">
+              <label for="nh-dtod" class="form-label">Platnost od</label>
+              <input type="date" class="form-control" id="nh-dtod" disabled>
+            </div>
+            <div class="col-sm-3">
+              <label for="nh-dtdo" class="form-label">Platnost do</label>
+              <input type="date" class="form-control" id="nh-dtdo" disabled>
+            </div>
+            <div class="col-12">
+              <label for="nh-poznamka" class="form-label">Poznámka</label>
+              <textarea id="nh-poznamka" class="form-control" rows="3" disabled></textarea>
+            </div>
+          </div>
+
+          <div class="mt-4">
+            <h6 class="mb-2 text-uppercase text-muted small">Varianty / ODS</h6>
+            <div id="nh-ods-container" class="d-flex flex-column gap-3"></div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <div class="me-auto small text-muted" id="nh-detail-meta"></div>
+          <div class="btn-group me-2">
+            <button type="button" class="btn btn-outline-primary" id="btn-nh-edit">Upravit</button>
+            <button type="button" class="btn btn-success d-none" id="btn-nh-save">Uložit</button>
+            <button type="button" class="btn btn-outline-danger" id="btn-nh-delete">Smazat</button>
+          </div>
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Zavřít</button>
+        </div>
+      </div>
+    </div>
   </div>
 
   <!-- Row action modal (polotovary) -->


### PR DESCRIPTION
## Summary
- extend the nh_get API to return NH/ODS details including price history and recipe data
- add a dedicated modal and toolbar button for viewing and editing NH detail records
- enhance the NH frontend controller to render ODS sections with active pricing and recipes

## Testing
- php -l api/nh_get.php

------
https://chatgpt.com/codex/tasks/task_b_6903544b31e08329a96a534745aac41c