### PR TITLE
Add accordion display for NH variants and recipe editor

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -313,6 +313,54 @@
             <h6 class="mb-2 text-uppercase text-muted small">Varianty / ODS</h6>
             <div id="nh-ods-container" class="d-flex flex-column gap-3"></div>
           </div>
+
+          <div class="mt-4 d-none" id="nh-recipe-editor">
+            <h6 class="mb-2 text-uppercase text-muted small">Aktuální receptura</h6>
+            <div class="card border-0 shadow-sm">
+              <div class="card-body">
+                <div class="row g-2 align-items-end">
+                  <div class="col-sm-3">
+                    <label for="nh-recipe-type" class="form-label">Typ položky</label>
+                    <select id="nh-recipe-type" class="form-select form-select-sm">
+                      <option value="sur">Surovina</option>
+                      <option value="pol">Polotovar</option>
+                      <option value="other">Ostatní</option>
+                    </select>
+                  </div>
+                  <div class="col-sm-3">
+                    <label for="nh-recipe-code" class="form-label">Kód</label>
+                    <input type="text" id="nh-recipe-code" class="form-control form-control-sm" placeholder="Např. 12345">
+                  </div>
+                  <div class="col-sm-4">
+                    <label for="nh-recipe-name" class="form-label">Název</label>
+                    <input type="text" id="nh-recipe-name" class="form-control form-control-sm" placeholder="Název položky">
+                  </div>
+                  <div class="col-sm-2">
+                    <label for="nh-recipe-amount" class="form-label">g / kg</label>
+                    <input type="number" step="0.01" min="0" id="nh-recipe-amount" class="form-control form-control-sm" placeholder="0,00">
+                  </div>
+                  <div class="col-12 text-end">
+                    <button type="button" class="btn btn-sm btn-outline-primary" id="nh-recipe-add">Přidat položku</button>
+                  </div>
+                </div>
+                <div class="table-responsive mt-3">
+                  <table class="table table-sm align-middle mb-0" id="nh-recipe-table">
+                    <thead class="table-light">
+                      <tr>
+                        <th style="width: 15%;">Typ</th>
+                        <th style="width: 20%;">Kód</th>
+                        <th>Název</th>
+                        <th class="text-end" style="width: 15%;">g / kg</th>
+                        <th style="width: 40px;"></th>
+                      </tr>
+                    </thead>
+                    <tbody></tbody>
+                  </table>
+                  <div class="text-center text-muted small py-3" id="nh-recipe-empty">Receptura zatím neobsahuje žádné položky.</div>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
         <div class="modal-footer">
           <div class="me-auto small text-muted" id="nh-detail-meta"></div>


### PR DESCRIPTION
## Summary
- render NH variant (ODS) details inside a Bootstrap accordion with collapsible sections
- add an in-modal recipe editor that appears when creating a new coating material and captures draft items
- include draft recipe items in the payload sent during NH creation

## Testing
- Manual smoke test: otevření karty NH, založení nové NH a přidání položky do receptury

------
https://chatgpt.com/codex/tasks/task_b_69035a73dc58832983593dd4f732ecd9