### PR TITLE
Add autocomplete suggestions for NH recipe inputs

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -329,11 +329,13 @@
                   </div>
                   <div class="col-sm-3">
                     <label for="nh-recipe-code" class="form-label">Kód</label>
-                    <input type="text" id="nh-recipe-code" class="form-control form-control-sm" placeholder="Např. 12345">
+                    <input type="text" id="nh-recipe-code" class="form-control form-control-sm" placeholder="Např. 12345" list="nh-recipe-code-suggestions">
+                    <datalist id="nh-recipe-code-suggestions"></datalist>
                   </div>
                   <div class="col-sm-4">
                     <label for="nh-recipe-name" class="form-label">Název</label>
-                    <input type="text" id="nh-recipe-name" class="form-control form-control-sm" placeholder="Název položky">
+                    <input type="text" id="nh-recipe-name" class="form-control form-control-sm" placeholder="Název položky" list="nh-recipe-name-suggestions">
+                    <datalist id="nh-recipe-name-suggestions"></datalist>
                   </div>
                   <div class="col-sm-2">
                     <label for="nh-recipe-amount" class="form-label">g / kg</label>


### PR DESCRIPTION
## Summary
- add datalists to the recipe code and name inputs in the NH detail modal
- implement debounced API-backed suggestion loading when creating a new coating recipe
- automatically synchronise code and name fields when a suggestion is chosen and clear the helper lists in relevant flows

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_69035d97eed88329820ade71400cca72