### PR TITLE
Fix escaped rendering of special characters across UI

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -2,6 +2,18 @@
   const $ = (s, p=document) => p.querySelector(s);
   const $$ = (s, p=document) => Array.from(p.querySelectorAll(s));
 
+  const escapeHtml = (value) => {
+    if (value === null || value === undefined) return '';
+    return String(value)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  };
+  const safeCell = (value) => escapeHtml(value ?? '');
+  const safeDate = (value) => (value ? escapeHtml(String(value).substring(0, 10)) : '');
+
   const showAlert = (msg, type='info') => {
     const box = $('#alert-box');
     box.className = `alert alert-${type}`;
@@ -194,13 +206,13 @@
         tr.setAttribute('data-id', r.id);
         tr.style.cursor = 'pointer';
         tr.innerHTML = `
-          <td>${r.id}</td>
-          <td>${r.cislo ?? ''}</td>
-          <td>${r.nazev ?? ''}</td>
-          <td>${r.sh ?? ''}</td>
-          <td>${r.okp ?? ''}</td>
-          <td>${r.olej ?? ''}</td>
-          <td>${r.pozn ?? ''}</td>
+          <td>${safeCell(r.id)}</td>
+          <td>${safeCell(r.cislo)}</td>
+          <td>${safeCell(r.nazev)}</td>
+          <td>${safeCell(r.sh)}</td>
+          <td>${safeCell(r.okp)}</td>
+          <td>${safeCell(r.olej)}</td>
+          <td>${safeCell(r.pozn)}</td>
         `;
         this.els.tableBody.appendChild(tr);
       }
@@ -336,8 +348,8 @@ function loadUsersTab(force = false) {
       pane.dataset.loaded = '1';
     })
     .catch(err => {
-      pane.innerHTML = '<div class="alert alert-danger m-3">Nepodařilo se načíst „Uživatelé“: ' +
-                       err.message + '</div>';
+      const msg = escapeHtml(err?.message || err);
+      pane.innerHTML = `<div class="alert alert-danger m-3">Nepodařilo se načíst „Uživatelé“: ${msg}</div>`;
     });
 }
 
@@ -420,15 +432,15 @@ document.addEventListener('DOMContentLoaded', () => {
       for (const r of items) {
         const tr = document.createElement('tr');
         tr.innerHTML = `
-          <td>${r.id}</td>
-          <td>${r.cislo ?? ''}</td>
-          <td>${r.nazev ?? ''}</td>
-          <td>${r.sh ?? ''}</td>
-          <td>${r.okp ?? ''}</td>
-          <td>${r.olej ?? ''}</td>
-          <td>${r.pozn ?? ''}</td>
-          <td>${r.dtod ? String(r.dtod).substring(0, 10) : ''}</td>
-          <td>${r.dtdo ? String(r.dtdo).substring(0, 10) : ''}</td>
+          <td>${safeCell(r.id)}</td>
+          <td>${safeCell(r.cislo)}</td>
+          <td>${safeCell(r.nazev)}</td>
+          <td>${safeCell(r.sh)}</td>
+          <td>${safeCell(r.okp)}</td>
+          <td>${safeCell(r.olej)}</td>
+          <td>${safeCell(r.pozn)}</td>
+          <td>${safeDate(r.dtod)}</td>
+          <td>${safeDate(r.dtdo)}</td>
         `;
         this.els.tbody.appendChild(tr);
       }

--- a/public/js/pol.controller.patch.js
+++ b/public/js/pol.controller.patch.js
@@ -10,6 +10,18 @@
   const $$ = (s, p=document) => Array.from(p.querySelectorAll(s));
   if (!window.API_URL) window.API_URL = '/balp2/api.php';
 
+  const escapeHtml = (value) => {
+    if (value === null || value === undefined) return '';
+    return String(value)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  };
+  const safeCell = (value) => escapeHtml(value ?? '');
+  const safeDate = (value) => (value ? escapeHtml(String(value).substring(0, 10)) : '');
+
   const storageKey='balp_token';
   const getToken = ()=>{ try{return localStorage.getItem(storageKey)||'';}catch(e){return '';} };
   const apiHeaders = ()=>{ const h={'Content-Type':'application/json'}; const t=getToken(); if(t) h['Authorization']='Bearer '+t; return h; };
@@ -115,7 +127,7 @@
       this.els.tbody.innerHTML='';
       for (const r of items){
         const tr=document.createElement('tr');
-        tr.innerHTML = `<td>${r.id}</td><td>${r.cislo??''}</td><td>${r.nazev??''}</td><td>${r.sh??''}</td><td>${r.okp??''}</td><td>${r.olej??''}</td><td>${r.pozn??''}</td><td>${r.dtod?String(r.dtod).substring(0,10):''}</td><td>${r.dtdo?String(r.dtdo).substring(0,10):''}</td>`;
+        tr.innerHTML = `<td>${safeCell(r.id)}</td><td>${safeCell(r.cislo)}</td><td>${safeCell(r.nazev)}</td><td>${safeCell(r.sh)}</td><td>${safeCell(r.okp)}</td><td>${safeCell(r.olej)}</td><td>${safeCell(r.pozn)}</td><td>${safeDate(r.dtod)}</td><td>${safeDate(r.dtdo)}</td>`;
         this.els.tbody.appendChild(tr);
       }
     }

--- a/public/js/pol.row-modal.js
+++ b/public/js/pol.row-modal.js
@@ -5,6 +5,16 @@
   if (!window.API_URL) window.API_URL = '/balp2/api.php';
   const storageKey='balp_token';
   const getToken = ()=>{ try{return localStorage.getItem(storageKey)||'';}catch(e){return '';} };
+
+  const escapeHtml = (value) => {
+    if (value === null || value === undefined) return '';
+    return String(value)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  };
   const withAuth = (url) => {
     const t = getToken();
     const u = new URL(url, location.origin);
@@ -73,16 +83,16 @@
     modal = bootstrap.Modal.getOrCreateInstance(modalEl);
   }
   function renderBody(row) {
-    const esc = (s) => (s==null?'':String(s));
+    const cell = (value) => escapeHtml(value ?? '');
     return `
       <div class="row g-3">
-        <div class="col-md-3"><div class="form-text">ID</div><div class="fw-semibold">${esc(row.id)}</div></div>
-        <div class="col-md-3"><div class="form-text">Číslo</div><div class="fw-semibold">${esc(row.cislo)}</div></div>
-        <div class="col-md-6"><div class="form-text">Název</div><div class="fw-semibold">${esc(row.nazev)}</div></div>
-        <div class="col-md-2"><div class="form-text">SH</div><div>${esc(row.sh)}</div></div>
-        <div class="col-md-2"><div class="form-text">OKP</div><div>${esc(row.okp)}</div></div>
-        <div class="col-md-2"><div class="form-text">Olej</div><div>${esc(row.olej)}</div></div>
-        <div class="col-md-12"><div class="form-text">Poznámka</div><div>${esc(row.pozn)}</div></div>
+        <div class="col-md-3"><div class="form-text">ID</div><div class="fw-semibold">${cell(row.id)}</div></div>
+        <div class="col-md-3"><div class="form-text">Číslo</div><div class="fw-semibold">${cell(row.cislo)}</div></div>
+        <div class="col-md-6"><div class="form-text">Název</div><div class="fw-semibold">${cell(row.nazev)}</div></div>
+        <div class="col-md-2"><div class="form-text">SH</div><div>${cell(row.sh)}</div></div>
+        <div class="col-md-2"><div class="form-text">OKP</div><div>${cell(row.okp)}</div></div>
+        <div class="col-md-2"><div class="form-text">Olej</div><div>${cell(row.olej)}</div></div>
+        <div class="col-md-12"><div class="form-text">Poznámka</div><div>${cell(row.pozn)}</div></div>
       </div>`;
   }
   async function openRowModal(id){
@@ -96,7 +106,8 @@
       $('#polRowModalBody').innerHTML = renderBody(data);
       $('#polRowMeta').textContent = 'ID: ' + id;
     } catch (e) {
-      $('#polRowModalBody').innerHTML = `<div class="alert alert-danger">Chyba načtení: ${e}</div>`;
+      const msg = escapeHtml(e?.message || e);
+      $('#polRowModalBody').innerHTML = `<div class="alert alert-danger">Chyba načtení: ${msg}</div>`;
     }
   }
 

--- a/public/js/pol.vp.core.js
+++ b/public/js/pol.vp.core.js
@@ -2,6 +2,16 @@
 // VP Core – datové volání + kompletní modál "Výrobní příkaz" (opravené sloupce, součty, přepočty)
 (() => {
   /* -------------------- Auth + API -------------------- */
+  const escapeHtml = (value) => {
+    if (value === null || value === undefined) return '';
+    return String(value)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  };
+  const safeCell = (value) => escapeHtml(value ?? '');
   function authHeaders() {
     const h = { 'Content-Type': 'application/json' };
     try {
@@ -32,7 +42,7 @@
   }
   function renderLoadingRow(tbody, text = 'Načítám…') {
     if (!tbody) return;
-    tbody.innerHTML = `<tr><td colspan="${colCountForBody(tbody)}">${text}</td></tr>`;
+    tbody.innerHTML = `<tr><td colspan="${colCountForBody(tbody)}">${escapeHtml(text)}</td></tr>`;
   }
   // jednotný renderer řádků pro „Suroviny“ i „Polotovary“
   function fillVpTable(tbody, rows) {
@@ -43,16 +53,16 @@
       const susObj = r.sus_obj  ?? r.susobj;
       const tr = document.createElement('tr');
       tr.innerHTML = `
-        <td>${r.techpor ?? ''}</td>
-        <td>${r.cislo ?? ''}</td>
-        <td>${r.nazev ?? ''}</td>
-        <td>${fmtDate(r.platnost_od)}</td>
-        <td>${fmtDate(r.platnost_do)}</td>
-        <td class="text-end">${fmtNum(r.sh)}</td>
-        <td class="text-end">${fmtNum(susHm)}</td>
-        <td class="text-end">${fmtNum(susObj)}</td>
-        <td class="text-end">${fmtNum(r.gkg)}</td>
-        <td class="text-end">${fmtNum(r.navazit_g)}</td>
+        <td>${safeCell(r.techpor)}</td>
+        <td>${safeCell(r.cislo)}</td>
+        <td>${safeCell(r.nazev)}</td>
+        <td>${safeCell(fmtDate(r.platnost_od))}</td>
+        <td>${safeCell(fmtDate(r.platnost_do))}</td>
+        <td class="text-end">${safeCell(fmtNum(r.sh))}</td>
+        <td class="text-end">${safeCell(fmtNum(susHm))}</td>
+        <td class="text-end">${safeCell(fmtNum(susObj))}</td>
+        <td class="text-end">${safeCell(fmtNum(r.gkg))}</td>
+        <td class="text-end">${safeCell(fmtNum(r.navazit_g))}</td>
       `;
       tbody.appendChild(tr);
     });
@@ -62,8 +72,8 @@
     const span = colCountForBody(tbody) - 1; // vše kromě posledního sloupce
     const tr = document.createElement('tr');
     tr.innerHTML = `
-      <td colspan="${span}" class="text-end"><strong>${label}</strong></td>
-      <td class="text-end"><strong>${fmtNum(sumValue)}</strong></td>
+      <td colspan="${span}" class="text-end"><strong>${safeCell(label)}</strong></td>
+      <td class="text-end"><strong>${safeCell(fmtNum(sumValue))}</strong></td>
     `;
     tbody.appendChild(tr);
   }


### PR DESCRIPTION
## Summary
- escape HTML-sensitive text when rendering suroviny and polotovary tables so diacritics and special characters display correctly
- sanitize modal and výrobní příkaz views to avoid corrupting or misinterpreting UTF-8 data
- add shared escaping helpers to front-end scripts to centralize safe text handling

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_69036b3bb87c8329a1f78e11085f9a6d